### PR TITLE
improve dev exp via configurable roots components

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,17 @@ Try `sudo npm run init` instead if errors pop up.
 <a name='running'></a>
 ### Running
 
+#### Basic
 ```
 npm start
 ```
+
+#### From specific root
+
+```
+npm start -- --component=SourcesView
+```
+with `SourcesView` an example of a possible root component. Those are defined in `app/isolated`
 
 ### Testing
 

--- a/app/isolated/SourcesView.js
+++ b/app/isolated/SourcesView.js
@@ -1,0 +1,23 @@
+import xs from 'xstream'
+import SourcesView from '../components/SourcesPanel/SourcesView'
+import resp1 from './resp-1.json'
+import { div } from '@cycle/dom'
+
+function transform (sources) {
+  const articleRep$ = xs.of(resp1)
+  return { articleRep$, ...sources }
+}
+
+function view (sv) {
+  return div('#Root', [div('#SourcesPanel', { attrs: { class: 'is-expanded' } }, [ div('#SourcesView_container', [sv]) ])])
+}
+
+function SV (sources) {
+  const transformedSources = transform(sources)
+  const vdom$ = SourcesView(transformedSources).DOM.map(view)
+  return {
+    DOM: vdom$
+  }
+}
+
+export default SV

--- a/app/isolated/resp-1.json
+++ b/app/isolated/resp-1.json
@@ -1,0 +1,75 @@
+{
+  "url": "http://www.bbc.com/news/world-europe-37147717",
+  "parseSuccess": true,
+  "errorCode": null,
+  "metaInfo": {
+    "title": "Turkey wedding suicide bomber 'was child aged 12-14' - BBC News",
+    "description": "The suicide bomber who killed 51 at a Kurdish wedding in Turkey was 12 to 14 years old and was working for so-called Islamic State, President Recep Tayyip Erdogan says.",
+    "authors": [
+      "BBC News"
+    ],
+    "provider": "BBC News",
+    "image": "http://ichef-1.bbci.co.uk/news/1024/cpsprodpb/1314C/production/_90865187_mediaitem90865186.jpg",
+    "ogType": "article",
+    "section": "Europe"
+  },
+  "standardsCompliance": {},
+  "socialLinks": [
+    "http://twitter.com/BBC_HaveYourSay"
+  ],
+  "internalArticleCandidates": [
+    "http://www.bbc.co.uk/news/world-europe-36181138",
+    "http://www.bbc.co.uk/news/world-middle-east-37143499",
+    "http://www.bbc.co.uk/news/live/world-europe-36659543",
+    "http://www.bbc.co.uk/news/world-europe-35829231",
+    "http://www.bbc.co.uk/news/world-europe-35599323",
+    "http://www.bbc.co.uk/news/world-europe-35290760",
+    "http://www.bbc.co.uk/news/world-europe-34495161"
+  ],
+  "sourcesCandidates": [
+    {
+      "url": "http://www.haberiyakala.com/2016-08-21-erdogan-gaziantepte-oynanan-oyun-tutmayacak-h269658.haber",
+      "parseSuccess": true,
+      "errorCode": null,
+      "metaInfo": {
+        "title": "Erdoğan: Gaziantep'te oynanan oyun tutmayacak",
+        "description": "Erdoğan: Gaziantep'te oynanan oyun tutmayacak",
+        "provider": "Haberi Yakala",
+        "image": "http://cdn.haberiyakala.com/assets/uploads/images/content/2016/08/21/cropped_content_erdogan-gaziantepte-oynanan-oyun-tutmayacak_UP27kbH9gBvr3jZ.jpg"
+      },
+      "standardsCompliance": {},
+      "socialLinks": [],
+      "internalArticleCandidates": [],
+      "sourcesCandidates": []
+    },
+    {
+      "url": "http://www.dha.com.tr/gaziantepte-patlama_1309851.html",
+      "parseSuccess": true,
+      "errorCode": null,
+      "metaInfo": {
+        "title": "Gaziantep'te terör saldırısı",
+        "description": "GAZİANTEP'te dün gece kına gecesinin yapıldığı sokağa terör saldırısı düzenlendi. Cumhurbaşkanı Erdoğan, ",
+        "provider": "Dha.com.tr",
+        "genre": "news",
+        "image": "http://www.dha.com.tr/newpics/news/210820160818149365751_2.jpg",
+        "ogType": "article",
+        "section": "Politika",
+        "location": "Istanbul, Turkey, Türkiye"
+      },
+      "standardsCompliance": {},
+      "socialLinks": [],
+      "internalArticleCandidates": [],
+      "sourcesCandidates": []
+    },
+    {
+      "url": "http://upload.news.bbc.cs.streamuk.com/",
+      "parseSuccess": false,
+      "errorCode": "UNKNOWN",
+      "sourcesCandidates": null,
+      "metaInfo": {},
+      "standardsCompliance": {},
+      "socialLinks": [],
+      "internalArticleCandidates": []
+    }
+  ]
+}

--- a/app/main.js
+++ b/app/main.js
@@ -1,19 +1,27 @@
 import { makeDOMDriver } from '@cycle/dom'
 import { makeHTTPDriver } from '@cycle/http'
 import Cycle from '@cycle/xstream-run'
-
+import rootMap from './root-map'
 import 'font-awesome/scss/font-awesome.scss'
 import 'normalize.css/normalize.css'
 import './style/main.scss'
 
-import Root from './components/Root'
-
 /**
- * A stream from xstream library
- * @typedef {Array} stream
+ *
+ * @param componentName - The component that should start at the root of the app
  */
-
-Cycle.run(Root, {
-  DOM: makeDOMDriver('#app'),
-  HTTP: makeHTTPDriver()
-})
+function main (componentName = 'Root') {
+  const normalizedCompName = componentName.toLowerCase()
+  let component = rootMap[normalizedCompName]
+  if (!component) {
+    console.error(`No component match for ${componentName}, defaulting to Root`)
+    component = rootMap.Root
+  } else {
+    console.info(`Component ${componentName} loading...`)
+  }
+  Cycle.run(component, {
+    DOM: makeDOMDriver('#app'),
+    HTTP: makeHTTPDriver()
+  })
+}
+main(process.env.APPLICATION_ROOT_COMP)

--- a/app/root-map.js
+++ b/app/root-map.js
@@ -1,0 +1,11 @@
+import SV from './isolated/SourcesView'
+import Root from './components/Root'
+
+const componentMap = {
+  root: Root,
+  r: Root,
+  sourcesview: SV,
+  sv: SV
+}
+
+export default componentMap

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "ramda": "^0.22.1",
     "readability": "file:./node_local_modules/readability/",
     "validator": "^5.5.0",
-    "xstream": "^6.1.0"
+    "xstream": "^6.1.0",
+    "yargs": "^6.4.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",

--- a/server/init-app.js
+++ b/server/init-app.js
@@ -3,14 +3,22 @@ import express from 'express'
 import webpack from 'webpack'
 import webpackMiddleware from 'webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'
-import config from '../webpack.config'
+import getAppConfig from '../webpack.config'
 import articleConfig from '../webpack.article.config'
-
+import { argv } from 'yargs'
 import initRoutes from './init-routes'
 import initSecurity from './init-security'
 
 const isDeveloping = process.env.NODE_ENV !== 'production'
 const app = express()
+
+function getApplicationRoot () {
+  let approot = null
+  if (argv.component || argv.c) {
+    approot = argv.component || argv.c
+  }
+  return approot
+}
 
 function useConfig (config) {
   const compiler = webpack(config)
@@ -31,7 +39,7 @@ function useConfig (config) {
 }
 
 if (isDeveloping) {
-  const middleware = useConfig(config)
+  const middleware = useConfig(getAppConfig(getApplicationRoot()))
   useConfig(articleConfig)
   app.get('/', function response (req, res) {
     res.write(middleware.fileSystem.readFileSync(path.join(__dirname, 'dist/index.html')))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,11 +2,11 @@ import path from 'path'
 import webpack from 'webpack'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 
-const appConfig = {
+const getAppConfig = (rootComponentName) => ({
   devtool: 'cheap-source-map',
   entry: [
     'webpack-hot-middleware/client?reload=true',
-    path.join(__dirname, 'app/main.js')
+    path.join(__dirname,'app/main.js')
   ],
   output: {
     path: path.join(__dirname, '/dist/'),
@@ -23,7 +23,8 @@ const appConfig = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('development')
+      'process.env.NODE_ENV': JSON.stringify('development'),
+      'process.env.APPLICATION_ROOT_COMP': JSON.stringify(rootComponentName)
     })
   ],
   resolve: {
@@ -49,6 +50,6 @@ const appConfig = {
     }
     ]
   }
-}
+})
 
-module.exports = appConfig
+module.exports = getAppConfig


### PR DESCRIPTION
- Allow nodejs option to be processed, via --component=MyComponent
or -c MyComponent
- Component aliases are defined in app/root-map
- Component names are case insensitive, lower-case cast
- New component root must be created in app/isolated